### PR TITLE
Multinline text alignes with padding

### DIFF
--- a/library/src/main/java/com/tylersuehr/esr/TextStateDisplay.java
+++ b/library/src/main/java/com/tylersuehr/esr/TextStateDisplay.java
@@ -285,7 +285,7 @@ public class TextStateDisplay extends AbstractStateDisplay {
             if ((titleLayout.getWidth() + totalNeededPadding) > availableWidth) {
                 this.titleLayout = new StaticLayout(title,
                         titlePaint,
-                        availableWidth,
+                        availableWidth - totalNeededPadding,
                         Layout.Alignment.ALIGN_NORMAL,
                         1.15f, 0, false);
             }

--- a/library/src/main/java/com/tylersuehr/esr/TextStateDisplay.java
+++ b/library/src/main/java/com/tylersuehr/esr/TextStateDisplay.java
@@ -294,7 +294,7 @@ public class TextStateDisplay extends AbstractStateDisplay {
             if ((subtitleLayout.getWidth() + totalNeededPadding) > availableWidth) {
                 this.subtitleLayout = new StaticLayout(subtitle,
                         subtitlePaint,
-                        availableWidth,
+                        availableWidth - totalNeededPadding,
                         Layout.Alignment.ALIGN_NORMAL,
                         1.15f, 0, false);
             }


### PR DESCRIPTION
The TextStateDisplay class did not keep the padding on multiline text, which extended the width of the text layout over the available screen width.
By creating a new layout with a width, that excludes the padding, the multiline text could now be aligned according to the specified padding.